### PR TITLE
trace: resolve stack corruption due to string copy

### DIFF
--- a/kernel/trace/trace.c
+++ b/kernel/trace/trace.c
@@ -1551,7 +1551,7 @@ static void __trace_find_cmdline(int pid, char comm[])
 
 	map = savedcmd->map_pid_to_cmdline[pid];
 	if (map != NO_CMDLINE_MAP)
-		strcpy(comm, get_saved_cmdlines(map));
+		strlcpy(comm, get_saved_cmdlines(map), TASK_COMM_LEN-1);
 	else
 		strcpy(comm, "<...>");
 }


### PR DESCRIPTION
Strcpy has no limit on string being copied which causes
stack corruption leading to kernel panic. Use strlcpy to
resolve the issue by providing length of string to be copied.

CRs-fixed: 1048480
Change-Id: Ib290b25f7e0ff96927b8530e5c078869441d409f
Signed-off-by: Amey Telawane <ameyt@codeaurora.org>